### PR TITLE
Fix: Implement robust session persistence

### DIFF
--- a/main.py
+++ b/main.py
@@ -713,7 +713,6 @@ def main():
 
     # Load persistent state
     server.keyword_extractor.load_corpus(corpus_filepath)
-    server.session_manager.load_all_sessions()
 
     # Register shutdown hook
     atexit.register(lambda: server.keyword_extractor.save_corpus(corpus_filepath))

--- a/session_manager.py
+++ b/session_manager.py
@@ -24,6 +24,7 @@ class SessionManager:
         if not os.path.exists(self.persistence_dir):
             os.makedirs(self.persistence_dir)
         logger.info(f"SessionManager initialized with persistence directory: {persistence_dir}")
+        self.load_all_sessions()
     
     def save_session(self, session_id: str):
         """Save a session's context to a file."""


### PR DESCRIPTION
The previous implementation failed to load persisted sessions on restart because the session loading logic was called in a code block that is not executed in all server environments (e.g., when run with a WSGI server).

This commit fixes the issue by moving the session loading call (`load_all_sessions()`) into the `SessionManager`'s `__init__` method. This ensures that sessions are always loaded from the persistence directory as soon as the `SessionManager` is instantiated, making the persistence mechanism robust and reliable regardless of how the application is started.

The redundant loading call was also removed from the `main()` function to clean up the code.